### PR TITLE
Refactor to allow for multiple actions

### DIFF
--- a/components/Canvas.tsx
+++ b/components/Canvas.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useCanvas } from "@hooks/useCanvas";
 import { useWindowResize } from "@hooks/useWindowResize";
-import { draw } from "@functions/canvasFunctions";
+import { draw, detectBoundary } from "@functions/canvasFunctions";
 
 export default function Canvas(): React.ReactNode {
   console.log("render canvas component");
@@ -21,12 +21,18 @@ export default function Canvas(): React.ReactNode {
 
     switch (e.target.value) {
       case "select":
-        setAction(() => ({ func: null, type: "select" }));
+        setAction(() => ({
+          func: detectBoundary as Rough.SelectFunc,
+          type: "select",
+        }));
         break;
       case "line":
       case "rect":
       case "circle":
-        setAction(() => ({ func: draw, type: e.target.value }));
+        setAction(() => ({
+          func: draw,
+          type: e.target.value,
+        }));
         break;
     }
   };

--- a/functions/canvasFunctions.ts
+++ b/functions/canvasFunctions.ts
@@ -27,7 +27,7 @@ export function draw({
       ),
     rect: () =>
       gen.rectangle(startPoint.x, startPoint.y, dim.w, dim.h, options),
-    circ: () => {
+    circle: () => {
       const x = (currentPoint.x + startPoint.x) / 2;
       const y = (currentPoint.y + startPoint.y) / 2;
 
@@ -96,7 +96,7 @@ export const detectBoundary = ({
             LINE_TOLERANCE,
           });
         },
-        circ: () => {
+        circle: () => {
           const { x, y } = startPoint;
           const { w, h } = currentDim;
           const a = w / 2;

--- a/hooks/useCanvas.ts
+++ b/hooks/useCanvas.ts
@@ -32,7 +32,6 @@ export const useCanvas = (onAction: {
   const roughRef = useRef<null | RoughCanvas>(null);
   const currentDrawActionRef = useRef<null | Rough.ActionHistory[]>(null);
   const currentSelectActionRef = useRef<null | {
-    elts: Rough.ActionHistory[][];
     newStartPoint?: Point;
     newDim?: Dim;
   }>(null);
@@ -311,7 +310,11 @@ export const useCanvas = (onAction: {
             y: currentPoint.y - offset.y,
           };
           currentSelectActionRef.current = {
-            elts: history.map((prevElts) =>
+            newStartPoint,
+          };
+
+          setHistory(
+            history.map((prevElts) =>
               prevElts.map((prevElt) =>
                 // note that canvas elts and move actions have the same id to reference each other
                 prevElt.action !== "move" && prevElt.id === id
@@ -322,11 +325,8 @@ export const useCanvas = (onAction: {
                     }
                   : prevElt
               )
-            ),
-            newStartPoint,
-          };
-
-          setHistory(currentSelectActionRef.current.elts);
+            )
+          );
         }
       }
     };

--- a/hooks/useCanvas.ts
+++ b/hooks/useCanvas.ts
@@ -416,7 +416,7 @@ export const useCanvas = (onAction: {
     return () => {
       canvasRef.current!.removeEventListener("mousemove", mouseMoveHandler);
     };
-  }, [onAction, history, index]);
+  }, [onAction, history, index, origin, scale]);
 
   useEffect(() => {
     console.log("effect resize");

--- a/hooks/useCanvas.ts
+++ b/hooks/useCanvas.ts
@@ -166,7 +166,7 @@ export const useCanvas = (onAction: {
               currentDim!.h,
               options
             ),
-          circ: () =>
+          circle: () =>
             gen.ellipse(
               startPoint!.x,
               startPoint!.y,

--- a/types/typing.d.ts
+++ b/types/typing.d.ts
@@ -8,7 +8,14 @@ type Dim = { w: number; h: number };
 type WindowSize = { innerWidth: number; innerHeight: number };
 
 declare namespace Rough {
+  type Action = DrawFunc | SelectFunc;
+  type ActionHistory = DrawProps | EditProps;
+  type ActionKeys = "line" | "rect" | "circ";
+
+  type DrawFunc = ({}: Draw) => DrawProps;
+
   type Draw = {
+    history: Rough.ActionHistory[][];
     action: string;
     rc: import("roughjs/bin/canvas").RoughCanvas;
     ctx?: CanvasRenderingContext2D;
@@ -22,10 +29,8 @@ declare namespace Rough {
     };
   };
 
-  type DrawFunc = ({}: Draw) => DrawProps;
-
   type DrawProps = {
-    id: null | number;
+    id: number;
     action: string;
     startPoint: Point;
     currentDim: Dim;
@@ -36,6 +41,45 @@ declare namespace Rough {
     };
   };
 
-  type Action = DrawFunc;
-  type ActionHistory = DrawProps;
+  type SelectFunc = ({}: Select) => SelectProps;
+
+  type Select = {
+    history: Rough.ActionHistory[][];
+    index: number;
+    mousePoint: Point;
+    CIRCLE_TOLERANCE: number;
+    LINE_TOLERANCE: number;
+  };
+
+  type SelectProps = null | Rough.DrawProps[];
+
+  type EditProps = {
+    id: number;
+    action: string;
+    newStartPoint?: Point;
+    startPoint?: Point;
+    newDim?: Dim;
+    currentDim?: Dim;
+    options?: {
+      seed?: number;
+      stroke?: string;
+      strokeWidth?: number;
+    };
+  };
+
+  type TestLines = {
+    startPoint: Point;
+    endPoint: Point;
+  };
+
+  type DetectLine = {
+    lines: TestLines[];
+    mousePoint: Point;
+    LINE_TOLERANCE: number;
+  };
+
+  type Distance = {
+    a: Point;
+    b: Point;
+  };
 }

--- a/types/typing.d.ts
+++ b/types/typing.d.ts
@@ -10,7 +10,7 @@ type WindowSize = { innerWidth: number; innerHeight: number };
 declare namespace Rough {
   type Action = DrawFunc | SelectFunc;
   type ActionHistory = DrawProps | EditProps;
-  type ActionKeys = "line" | "rect" | "circ";
+  type ActionKeys = "line" | "rect" | "circle";
 
   type DrawFunc = ({}: Draw) => DrawProps;
 


### PR DESCRIPTION
In an attempt to keep the history array as minimal as possible, actions like move and resize will be bare minimal objects that contain a reference id to the original element in the array. Using this reference id and property of the previous and new points it will allow undo/redo with minimal effort.

* Change history to be a 2d-array to allow for multiple actions like selecting and moving a bunch of canvasElements in the future
* Moved detectBoundary out to canvasFunctions and set it as the select function
* Able to undo/redo movement of canvasElements
* Turned some switch statements to object literals