### PR TITLE
Bug Fix for Shift Selection and Preliminary Detection of Resize for Line Elements

### DIFF
--- a/constants/canvasConstants.ts
+++ b/constants/canvasConstants.ts
@@ -7,6 +7,7 @@ const MAX_SCALE: number = 5;
 const ZOOM_OUT_FACTOR: number = 0.9;
 const ZOOM_IN_FACTOR: number = 1.1;
 const LINE_TOLERANCE: number = 1;
+const POINT_TOLERANCE: number = 5;
 const CIRCLE_TOLERANCE: number = 0.07;
 const DELAY: number = 100;
 const RESIZE_RADIUS: number = 5;
@@ -24,6 +25,7 @@ export {
 	ZOOM_OUT_FACTOR,
 	ZOOM_IN_FACTOR,
 	LINE_TOLERANCE,
+	POINT_TOLERANCE,
 	CIRCLE_TOLERANCE,
 	DELAY,
 	GEN,

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "export": "npx serve@latest out"
   },
   "dependencies": {
-    "@rwh/keystrokes": "^1.2.0",
-    "@rwh/react-keystrokes": "^1.2.0",
+    "@rwh/keystrokes": "^1.2.1",
+    "@rwh/react-keystrokes": "^1.2.1",
     "autoprefixer": "10.4.15",
     "next": "13.4.19",
     "postcss": "8.4.28",
@@ -22,8 +22,8 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
-    "@types/node": "20.5.1",
-    "@types/react": "18.2.20",
+    "@types/node": "20.5.4",
+    "@types/react": "18.2.21",
     "@types/react-dom": "18.2.7",
     "@types/uuid": "^9.0.2",
     "eslint": "8.47.0",
@@ -32,6 +32,6 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "prettier": "^3.0.2",
     "prettier-plugin-tailwindcss": "^0.5.3",
-    "typescript": "5.1.6"
+    "typescript": "5.2.2"
   }
 }

--- a/types/typing.d.ts
+++ b/types/typing.d.ts
@@ -45,6 +45,11 @@ type DetectLine = {
 	mousePoint: Point;
 };
 
+type DetectPoint = {
+	point: Point;
+	mousePoint: Point;
+};
+
 type DetectInsideBox = {
 	tl: Point;
 	br: Point;
@@ -67,7 +72,6 @@ declare namespace Rough {
 	type DrawFunc = ({}: Draw) => DrawProps[];
 
 	type Draw = {
-		history: Rough.ActionHistory[][];
 		action: Rough.ActionDraw;
 		rc: import("roughjs/bin/canvas").RoughCanvas;
 		ctx?: CanvasRenderingContext2D;
@@ -102,9 +106,10 @@ declare namespace Rough {
 		selectedElements: Rough.ActionHistory[];
 		multiSelectBox: Rough.Points;
 		mousePoint: Point;
+		isShift: boolean;
 	};
 
-	type SelectProps = { elts: null | Rough.DrawProps; action: type };
+	type SelectProps = { elts: null | Rough.DrawProps[]; action: type };
 
 	type DetectBoundaryTransparentNoSelectedElements = {
 		elt: Rough.DrawProps;
@@ -118,6 +123,13 @@ declare namespace Rough {
 	};
 
 	type DetectBoundaryMultiSelectedElements = {
+		selectedElements: Rough.ActionHistory[];
+		multiSelectBox: Rough.Points;
+		mousePoint: Point;
+	};
+
+	type DetectBoundaryAndSelectionShift = {
+		history: Rough.ActionHistory[][];
 		selectedElements: Rough.ActionHistory[];
 		multiSelectBox: Rough.Points;
 		mousePoint: Point;

--- a/yarn.lock
+++ b/yarn.lock
@@ -185,15 +185,15 @@
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.3.3.tgz#16ab6c727d8c2020a5b6e4a176a243ecd88d8d69"
   integrity sha512-0xd7qez0AQ+MbHatZTlI1gu5vkG8r7MYRUJAHPAHJBmGLs16zpkrpAVLvjQKQOqaXPDUBwOiJzNc00znHSCVBw==
 
-"@rwh/keystrokes@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@rwh/keystrokes/-/keystrokes-1.2.0.tgz#fb73464317b7aba1d50b16c98a30fc023f95f911"
-  integrity sha512-RJBtQwWp/T75ltlFwYFb4dcr4n2GX/HGmTBJ2jDfkonzUAH5klUyTYDc3biFr08tiXQmlcspZIukJMfAq+a/XQ==
+"@rwh/keystrokes@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rwh/keystrokes/-/keystrokes-1.2.1.tgz#647751b462be28e11aba001ee48a41a423cede6f"
+  integrity sha512-und8tL402faMVZVBl5lkHRpa7MsvnUOJDsx2Sc1rHO0zlzUA4ytMVquCz+L4VUWwpYEHgY709KOm794PF5YnKw==
 
-"@rwh/react-keystrokes@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@rwh/react-keystrokes/-/react-keystrokes-1.2.0.tgz#a3fc889a9b279a4f40bdb46efca4842038864eef"
-  integrity sha512-tC4j4+1ijglrNDfRUhUQg5yNEjOufStZY3LH8A1H1e5d5QHKiWU/eQEFfbxi7c75aGj/dUgn+b7AG7mcAOdNQw==
+"@rwh/react-keystrokes@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rwh/react-keystrokes/-/react-keystrokes-1.2.1.tgz#bebe2c8a6d2c452310d9cd6599a57875faeb6490"
+  integrity sha512-PWszOquZwV4wGakVD2fW01Kq5BlKq+2Yw/AeoABVeKGQspeeQbyP6NSq5Tov6aUsUuS1KOJO7F6RRPivd7MpPQ==
 
 "@swc/helpers@0.5.1":
   version "0.5.1"
@@ -207,10 +207,10 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/node@20.5.1":
-  version "20.5.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.5.1.tgz#178d58ee7e4834152b0e8b4d30cbfab578b9bb30"
-  integrity sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg==
+"@types/node@20.5.4":
+  version "20.5.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.5.4.tgz#4666fb40f9974d60c53c4ff554315860ba4feab8"
+  integrity sha512-Y9vbIAoM31djQZrPYjpTLo0XlaSwOIsrlfE3LpulZeRblttsLQRFRlBAppW0LOxyT3ALj2M5vU1ucQQayQH3jA==
 
 "@types/prop-types@*":
   version "15.7.5"
@@ -224,10 +224,19 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@18.2.20":
+"@types/react@*":
   version "18.2.20"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.20.tgz#1605557a83df5c8a2cc4eeb743b3dfc0eb6aaeb2"
   integrity sha512-WKNtmsLWJM/3D5mG4U84cysVY31ivmyw85dE84fOCk5Hx78wezB/XEjVPWl2JTZ5FkEeaTJf+VgUAUn3PE7Isw==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@18.2.21":
+  version "18.2.21"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.21.tgz#774c37fd01b522d0b91aed04811b58e4e0514ed9"
+  integrity sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -2382,10 +2391,10 @@ typed-array-length@^1.0.4:
     for-each "^0.3.3"
     is-typed-array "^1.1.9"
 
-typescript@5.1.6:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
-  integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
+typescript@5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Shift selection was not working correctly and was crashing in pr #51. 

This was because the detectBoundary function was either returning an element or an array. It is now defaulted to an array. 

Other issues were that it was defaulting to the detectBoundaryMultiSelectedElements function for its logic. However, this function doesn't detect any shapes thus you could only selected 2 elements at max. 

Now shift selection use both detectBoundarySingleSelectedElement and detectBoundaryMultiSelectedElements in its logic returning the current selectedElements array

Other Changes:
* Preliminary detection of resize for line elements was added
* Added new cursor styles, for resizing lines and panning 